### PR TITLE
Override exclude settings in Cypress tsconfig

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../tsconfig.json",
+  "exclude": [],
   "include": ["**/*.ts"],
   "compilerOptions": {
     "sourceMap": false,


### PR DESCRIPTION
## Summary
- override the default `exclude` settings in `cypress/tsconfig.json`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ba9953908332813c640411d43a55