### PR TITLE
Update README with headless browser testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ ng test
 Pruebas e2e:
 ng e2e
 
+## Pruebas con navegador headless
+
+1. Instala Chromium/Chrome y su driver:
+   `sudo apt-get install -y chromium-browser chromium-chromedriver`
+2. Ejecuta las pruebas unitarias en modo headless:
+   `npm test -- --browsers=ChromeHeadlessCustom --watch=false`
+3. Si Karma no encuentra Chrome, usa la ruta que provee Puppeteer:
+   `CHROME_BIN=$(node -p "require('puppeteer').executablePath()") npm test -- --browsers=ChromeHeadlessCustom --watch=false`
+
 ## Más info
 Documentación oficial de Angular: https://angular.io
 


### PR DESCRIPTION
## Summary
- document installing Chrome/Chromium
- show how to run Karma tests in headless mode
- point to Puppeteer's Chrome if the browser is missing

## Testing
- `CHROME_BIN=$HOME/.cache/puppeteer/chrome/linux-138.0.7204.49/chrome-linux64/chrome npm test -- --browsers=ChromeHeadlessCustom --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6862ba97fd7c8332bc028620c50514c1