### PR TITLE
Add note about Cypress tsconfig usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ ng test
 Pruebas e2e:
 ng e2e
 
+Compilar las pruebas de Cypress con TypeScript:
+`npx tsc -p cypress/tsconfig.json`
+Si tu herramienta usa otra ruta, verifica que no agregue un segundo `cypress/`.
+
 ## Pruebas con navegador headless
 
 1. Instala Chromium/Chrome y su driver:


### PR DESCRIPTION
## Summary
- document how to compile Cypress tests with TypeScript

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6862c9a4a920833297bb6df9564ea98d