### PR TITLE
Fix cypress install issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@cypress/schematic": "^2.5.2",
         "@types/jasmine": "~4.3.0",
         "cypress": "13.2.0",
+        "is-ci": "^4.1.0",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -9573,6 +9574,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
+      "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.1.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@cypress/schematic": "^2.5.2",
     "@types/jasmine": "~4.3.0",
     "cypress": "13.2.0",
+    "is-ci": "^4.1.0",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",


### PR DESCRIPTION
## Summary
- add `is-ci` devDependency to avoid cypress postinstall failure

## Testing
- `npm install`
- `CHROME_BIN=$(node -p "require('puppeteer').executablePath()") npm test --silent -- --browsers=ChromeHeadlessCustom --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6862d3a84d508332a4422736a9a92d28