### PR TITLE
Fix responsive grid classes

### DIFF
--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -63,7 +63,7 @@
 
   <h4 class="text-center mt-4">Lista de Productos</h4>
   <div class="row">
-    <div class="col-md-4 mb-3" *ngFor="let p of productos">
+    <div class="col-12 col-sm-6 col-lg-4 mb-3" *ngFor="let p of productos">
       <div class="card h-100">
         <img [src]="p.imagen" class="card-img-top" [alt]="p.nombre" />
         <div class="card-body d-flex flex-column">

--- a/src/app/pages/catalogo/catalogo.component.html
+++ b/src/app/pages/catalogo/catalogo.component.html
@@ -1,7 +1,7 @@
 <div class="container-fluid mt-4">
   <h2 class="text-center mb-4">Catálogo de Productos</h2>
   <div class="row">
-    <div class="col-md-4 mb-4" *ngFor="let producto of productos">
+    <div class="col-12 col-sm-6 col-lg-4 mb-4" *ngFor="let producto of productos">
       <div class="card h-100 shadow rounded-4">
         <img 
           [src]="producto.imagen" 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -10,7 +10,7 @@
 <div class="container-fluid py-5">
   <h2 class="mb-4">Productos Destacados</h2>
   <div class="row">
-    <div *ngFor="let p of productos" class="col-md-4 mb-3">
+    <div *ngFor="let p of productos" class="col-12 col-sm-6 col-lg-4 mb-3">
       <div class="card">
         <img [src]="p.imagen" class="card-img-top" alt="{{ p.nombre }}">
         <div class="card-body">

--- a/src/app/pages/producto-detalle/producto-detalle.component.html
+++ b/src/app/pages/producto-detalle/producto-detalle.component.html
@@ -1,9 +1,9 @@
 <div class="container py-5">
   <div *ngIf="producto" class="row">
-    <div class="col-md-6">
+    <div class="col-12 col-md-6">
       <img [src]="producto.imagen" alt="Producto" class="img-fluid rounded shadow-sm" />
     </div>
-    <div class="col-md-6">
+    <div class="col-12 col-md-6">
       <h2 class="mb-3">{{ producto.nombre }}</h2>
       <p class="text-muted">{{ producto.descripcion }}</p>
       <h4 class="text-dark mb-4">${{ producto.precio }}</h4>


### PR DESCRIPTION
## Summary
- make product grids responsive across viewport widths

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadlessCustom`
- `npx ng build`


------
https://chatgpt.com/codex/tasks/task_e_6862f522425883328b639105990ab06e