### PR TITLE
Add route guards for auth and admin

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,8 @@
 // Define las rutas principales que mapean URLs a componentes.
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from './guards/auth.guard';
+import { AdminGuard } from './guards/admin.guard';
 
 import { HomeComponent } from './pages/home/home.component';
 import { CatalogoComponent } from './pages/catalogo/catalogo.component';
@@ -24,9 +26,9 @@ const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'registro', component: RegistroComponent },
   { path: 'recuperar', component: RecuperarComponent },
-  { path: 'perfil', component: PerfilComponent },
+  { path: 'perfil', component: PerfilComponent, canActivate: [AuthGuard] },
   { path: 'contacto', component: ContactoComponent },
-  { path: 'admin', component: AdminComponent },
+  { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
   { path: 'create-user', component: CreateUserComponent },
   { path: 'acerca', component: AcercaComponent },
   // Ruta por defecto si no existe coincidencia

--- a/src/app/guards/admin.guard.spec.ts
+++ b/src/app/guards/admin.guard.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AdminGuard } from './admin.guard';
+
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule]
+    });
+    guard = TestBed.inject(AdminGuard);
+    router = TestBed.inject(Router);
+    localStorage.clear();
+  });
+
+  it('should allow admin user', () => {
+    localStorage.setItem('usuario', JSON.stringify({ email: 'admin@example.com' }));
+    expect(guard.canActivate()).toBeTrue();
+  });
+
+  it('should redirect normal user to /perfil', () => {
+    localStorage.setItem('usuario', JSON.stringify({ email: 'user@example.com' }));
+    spyOn(router, 'navigate');
+    expect(guard.canActivate()).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/perfil']);
+  });
+
+  it('should redirect unauthenticated user to /login', () => {
+    spyOn(router, 'navigate');
+    expect(guard.canActivate()).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class AdminGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean {
+    const raw = localStorage.getItem('usuario');
+    if (!raw) {
+      this.router.navigate(['/login']);
+      return false;
+    }
+    const user = JSON.parse(raw);
+    if (user.email === 'admin@example.com') {
+      return true;
+    }
+    this.router.navigate(['/perfil']);
+    return false;
+  }
+}

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule]
+    });
+    guard = TestBed.inject(AuthGuard);
+    router = TestBed.inject(Router);
+    localStorage.clear();
+  });
+
+  it('should allow when user exists', () => {
+    localStorage.setItem('usuario', JSON.stringify({ email: 'user@example.com' }));
+    expect(guard.canActivate()).toBeTrue();
+  });
+
+  it('should redirect to /login when no user', () => {
+    spyOn(router, 'navigate');
+    expect(guard.canActivate()).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean {
+    const raw = localStorage.getItem('usuario');
+    if (raw) {
+      return true;
+    }
+    this.router.navigate(['/login']);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add `AuthGuard` and `AdminGuard`
- protect profile and admin routes with the new guards
- test guards behavior

## Testing
- `npx -y @angular/cli test --watch=false --browsers=ChromeHeadlessCustom`

------
https://chatgpt.com/codex/tasks/task_e_6862f524ecb4833294e2d798ea00c020