### PR TITLE
Add full login and cart Cypress test

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,16 +1,32 @@
 describe('PinnaCosta App', () => {
-  it('Visits the initial project page and shows header items', () => {
+  it('Visits the initial project page and shows main content', () => {
     cy.visit('/')
 
-    
     cy.get('app-header img[alt="Logo"]').should('be.visible')
 
-   
+    cy.contains('h1', 'Acerca de Piña Costa').should('be.visible')
+
     cy.get('app-header').within(() => {
       cy.contains('Inicio').should('have.attr', 'href', '/')
       cy.contains('Acerca de').should('have.attr', 'href', '/acerca')
       cy.contains('Catálogo').should('have.attr', 'href', '/catalogo')
       cy.contains('Carrito').should('exist')
     })
+  })
+
+  it('allows a user to login and add a product to the cart', () => {
+    cy.visit('/login')
+
+    cy.get('input[id="email"]').type('usuario')
+    cy.get('input[id="password"]').type('usuario')
+    cy.contains('button', 'Ingresar').click()
+
+    cy.url().should('include', '/perfil')
+
+    cy.visit('/catalogo')
+    cy.contains('button', 'Agregar al carrito').first().click()
+
+    cy.visit('/cart')
+    cy.get('tbody tr').should('have.length.at.least', 1)
   })
 })


### PR DESCRIPTION
## Summary
- update home page test to check for real text
- add Cypress flow for login, catalog navigation, add-to-cart

## Testing
- `npm test -- --watch=false`
- `xvfb-run -a npm run cypress:run` *(fails: could not verify server running)*

------
https://chatgpt.com/codex/tasks/task_e_68631209bed48332ac02abdb5e04c344