### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npx ng lint
+      - name: Unit tests
+        run: npx ng test --watch=false
+      - name: End-to-end tests
+        run: npx ng e2e --watch=false --headless

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PinnaCosta
+[![CI](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml/badge.svg)](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml)
 
  **Tienda online** creada con **Angular 16** para el ramo de Programación. Muestra productos de moda femenina, carrito de compras y cuenta de usuario con formularios reactivos y validaciones.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running `npm ci`, `ng lint`, `ng test`, and `ng e2e`
- include a CI badge in the README

## Testing
- `npm ci`
- `npx ng lint` *(fails: Cannot find "lint" target)*
- `npx ng test --watch=false`
- `npx ng e2e --watch=false --headless` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6863122763248332944ac4a1794c03d5