### PR TITLE
Implement lazy-loaded feature modules

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,15 +7,11 @@ import { AuthGuard } from './guards/auth.guard';
 import { AdminGuard } from './guards/admin.guard';
 
 import { HomeComponent } from './pages/home/home.component';
-import { CatalogoComponent } from './pages/catalogo/catalogo.component';
 import { ProductoDetalleComponent } from './pages/producto-detalle/producto-detalle.component';
 import { CartComponent } from './pages/cart/cart.component';
-import { LoginComponent } from './pages/login/login.component';
-import { RegistroComponent } from './pages/registro/registro.component';
 import { RecuperarComponent } from './pages/recuperar/recuperar.component';
 import { PerfilComponent } from './pages/perfil/perfil.component';
 import { ContactoComponent } from './pages/contacto/contacto.component';
-import { AdminComponent } from './pages/admin/admin.component';
 import { CreateUserComponent } from './pages/create-user/create-user.component';
 import { AcercaComponent } from './pages/acerca/acerca.component';
 
@@ -24,15 +20,15 @@ import { AcercaComponent } from './pages/acerca/acerca.component';
  */
 const routes: Routes = [
   { path: '', component: HomeComponent },
-  { path: 'catalogo', component: CatalogoComponent },
+  { path: 'catalogo', loadChildren: () => import('./pages/catalogo/catalogo.module').then(m => m.CatalogoModule) },
   { path: 'producto/:id', component: ProductoDetalleComponent },
   { path: 'cart', component: CartComponent },
-  { path: 'login', component: LoginComponent },
-  { path: 'registro', component: RegistroComponent },
+  { path: 'login', loadChildren: () => import('./pages/login/login.module').then(m => m.LoginModule) },
+  { path: 'registro', loadChildren: () => import('./pages/registro/registro.module').then(m => m.RegistroModule) },
   { path: 'recuperar', component: RecuperarComponent },
   { path: 'perfil', component: PerfilComponent, canActivate: [AuthGuard] },
   { path: 'contacto', component: ContactoComponent },
-  { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
+  { path: 'admin', loadChildren: () => import('./pages/admin/admin.module').then(m => m.AdminModule), canActivate: [AdminGuard] },
   { path: 'create-user', component: CreateUserComponent },
   { path: 'acerca', component: AcercaComponent },
   // Ruta por defecto si no existe coincidencia

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,15 +11,11 @@ import { SharedModule } from './shared/shared.module';
 
 import { AppComponent } from './app.component';
 import { HomeComponent } from './pages/home/home.component';
-import { CatalogoComponent } from './pages/catalogo/catalogo.component';
 import { ProductoDetalleComponent } from './pages/producto-detalle/producto-detalle.component';
 import { CartComponent } from './pages/cart/cart.component';
-import { LoginComponent } from './pages/login/login.component';
-import { RegistroComponent } from './pages/registro/registro.component';
 import { RecuperarComponent } from './pages/recuperar/recuperar.component';
 import { PerfilComponent } from './pages/perfil/perfil.component';
 import { ContactoComponent } from './pages/contacto/contacto.component';
-import { AdminComponent } from './pages/admin/admin.component';
 import { CreateUserComponent } from './pages/create-user/create-user.component';
 import { AcercaComponent } from './pages/acerca/acerca.component';
 
@@ -28,15 +24,11 @@ import { AcercaComponent } from './pages/acerca/acerca.component';
   declarations: [
     AppComponent,
     HomeComponent,
-    CatalogoComponent,
     ProductoDetalleComponent,
     CartComponent,
-    LoginComponent,
-    RegistroComponent,
     RecuperarComponent,
     PerfilComponent,
     ContactoComponent,
-    AdminComponent,
     CreateUserComponent,
     AcercaComponent
   ],

--- a/src/app/pages/admin/admin.module.ts
+++ b/src/app/pages/admin/admin.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { AdminComponent } from './admin.component';
+
+const routes: Routes = [
+  { path: '', component: AdminComponent }
+];
+
+@NgModule({
+  declarations: [AdminComponent],
+  imports: [CommonModule, FormsModule, RouterModule.forChild(routes)]
+})
+export class AdminModule {}

--- a/src/app/pages/catalogo/catalogo.module.ts
+++ b/src/app/pages/catalogo/catalogo.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterModule, Routes } from '@angular/router';
+import { CatalogoComponent } from './catalogo.component';
+
+const routes: Routes = [
+  { path: '', component: CatalogoComponent }
+];
+
+@NgModule({
+  declarations: [CatalogoComponent],
+  imports: [CommonModule, HttpClientModule, RouterModule.forChild(routes)]
+})
+export class CatalogoModule {}

--- a/src/app/pages/login/login.module.ts
+++ b/src/app/pages/login/login.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './login.component';
+
+const routes: Routes = [
+  { path: '', component: LoginComponent }
+];
+
+@NgModule({
+  declarations: [LoginComponent],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule.forChild(routes)]
+})
+export class LoginModule {}

--- a/src/app/pages/registro/registro.module.ts
+++ b/src/app/pages/registro/registro.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { RegistroComponent } from './registro.component';
+
+const routes: Routes = [
+  { path: '', component: RegistroComponent }
+];
+
+@NgModule({
+  declarations: [RegistroComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule.forChild(routes)]
+})
+export class RegistroModule {}


### PR DESCRIPTION
## Summary
- create LoginModule, RegistroModule, CatalogoModule and AdminModule
- remove these components from AppModule
- lazy-load the new modules in AppRoutingModule

## Testing
- `npm run build`
- `ng test --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_6863129526f4833286d6f65aa125ac6c