### PR TITLE
Replace clickable links with buttons

### DIFF
--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -33,12 +33,20 @@ h2 {
   border: none;
 }
 
-.extra-links a {
+.extra-links a,
+.extra-links button {
   color: #d63384;
   cursor: pointer;
   font-weight: bold;
+  background: none;
+  border: none;
+  padding: 0;
 }
 
-.extra-links a:hover {
+.extra-links a:hover,
+.extra-links button:hover,
+.extra-links button:focus {
   text-decoration: underline;
+  outline: 2px solid #d63384;
+  outline-offset: 2px;
 }

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -37,8 +37,8 @@
     <button type="button" class="btn btn-outline-dark w-100 mt-2" (click)="limpiar()">Limpiar</button>
 
     <div class="extra-links mt-3 text-center">
-      <a (click)="recuperarPassword()">¿Olvidaste tu contraseña?</a> |
-      <a (click)="registrarse()">Regístrate</a>
+      <button type="button" (click)="recuperarPassword()">¿Olvidaste tu contraseña?</button> |
+      <button type="button" (click)="registrarse()">Regístrate</button>
     </div>
 
     <div class="alert alert-danger mt-3" *ngIf="error">{{ error }}</div>


### PR DESCRIPTION
## Summary
- convert interactive `<a>` elements in Login page to `<button>`
- style new buttons so they look like links and keep focus outlines

## Testing
- `npm test -- --browsers=ChromeHeadlessCustom --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_686315a17b5c83328dd8deec869f8cbf