### PR TITLE
Fix Karma tests with Chrome headless

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,6 @@
 process.env.CHROME_BIN = require('puppeteer').executablePath() || '/usr/bin/chromium-browser';
 module.exports = function (config) {
+  const browsers = (config.browsers || ['ChromeHeadless']);
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
@@ -24,11 +25,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadlessCustom'],
+    browsers,
     customLaunchers: {
-      ChromeHeadlessCustom: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--headless', '--disable-gpu', '--disable-dev-shm-usage']
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: ['--headless', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--remote-debugging-port=9222']
       }
     },
     singleRun: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@angular/compiler-cli": "^16.2.0",
         "@compodoc/compodoc": "^1.1.26",
         "@cypress/schematic": "^2.5.2",
+        "@types/jasmine": "^5.1.8",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "angular-cli-ghpages": "^2.0.3",
@@ -4902,6 +4903,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.8.tgz",
+      "integrity": "sha512-u7/CnvRdh6AaaIzYjCgUuVbREFgulhX05Qtf6ZtW+aOcjCKKVvKgpkPYJBFTZSHtFBYimzU4zP0V2vrEsq9Wcg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@angular/compiler-cli": "^16.2.0",
     "@compodoc/compodoc": "^1.1.26",
     "@cypress/schematic": "^2.5.2",
+    "@types/jasmine": "^5.1.8",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "angular-cli-ghpages": "^2.0.3",


### PR DESCRIPTION
## Summary
- install Jasmine types
- update Karma launcher to use no-sandbox flags so tests run as root

## Testing
- `npx ng lint pinna-costa`
- `npm run test -- --watch=false --browsers=ChromeHeadless`


------
https://chatgpt.com/codex/tasks/task_e_686336862b648332af265f4cd1942cf0