### PR TITLE
Fix login redirect in e2e

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -21,7 +21,7 @@ describe('PinnaCosta App', () => {
     cy.get('input[id="password"]').type('admin123')
     cy.contains('button', 'Ingresar').click()
 
-    cy.url().should('include', '/perfil')
+    cy.url().should('include', '/admin')
 
     cy.visit('/catalogo')
     cy.contains('button', 'Agregar al carrito').first().click()


### PR DESCRIPTION
## Summary
- correct admin redirect path in Cypress test

## Testing
- `npx ng lint pinna-costa`
- `npm run test -- --watch=false --browsers=ChromeHeadless`
- `xvfb-run -a npm run e2e` *(fails: connect ECONNREFUSED 127.0.0.1:4200)*

------
https://chatgpt.com/codex/tasks/task_e_68634a0a9db083328082cb982546b4d8